### PR TITLE
feat(semver):SP-4173 add GetVersionFromReqOperator to strip semver op…

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
 
       - name: Unit Test
         run: make unit_test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
 
       - name: Unit Test
         run: make unit_test

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.txt
+*.json
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,89 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+formatters:
+  enable:
+    - gci
+    - goimports
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+
+linters:
+  enable:
+    - cyclop
+    - errname
+    - exhaustive
+    - funlen
+    - gocognit
+    - goconst
+    - gocritic
+    - godot
+    - gosec
+    - lll
+    - loggercheck
+    - makezero
+    - nakedret
+    - nilerr
+    - nilnil
+    - nolintlint
+    - nonamedreturns
+    - predeclared
+    - reassign
+    - staticcheck
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - whitespace
+
+  settings:
+    cyclop:
+      max-complexity: 30
+      package-average: 10.0
+
+    errcheck:
+      check-type-assertions: true
+
+    exhaustive:
+      check:
+        - switch
+        - map
+
+    funlen:
+      lines: 150
+      statements: 80
+
+    gocognit:
+      min-complexity: 40
+
+    gosec:
+      excludes:
+        - G117
+        - G304
+
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+      settings:
+        shadow:
+          strict: true
+
+    nakedret:
+      max-func-lines: 10
+
+    lll:
+      line-length: 180
+
+    staticcheck:
+      checks: ["all", "-SA1019"]
+
+  exclusions:
+    paths:
+      - tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2026-03-19
 ### Added
 - Added `GetVersionFromReqOperator` function to strip all common semver operators (`>=`, `<=`, `!=`, `~=`, `==`, `>`, `<`, `=`, `~`, `^`) and `v` prefix from version requirement strings
+- Added `conan` PURL to URL conversion
 ### Fixed
 - Replaced `strings.Replace` with `strings.ReplaceAll` in `ConvertGoPurlStringToGithub` to satisfy linter
 
@@ -21,10 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added GH Workflows and linting
 
-
 ## [0.0.1] - 2022-10-21
 ### Added
-- Added initial set of Purl helper functions
+- Added an initial set of Purl helper functions
 
 [0.0.1]: https://github.com/scanoss/go-purl-helper/compare/v0.0.0...v0.0.1
 [0.1.0]: https://github.com/scanoss/go-purl-helper/compare/v0.0.1...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0] - 2026-03-19
 ### Added
-- Upcoming changes...
+- Added `GetVersionFromReqOperator` function to strip all common semver operators (`>=`, `<=`, `!=`, `~=`, `==`, `>`, `<`, `=`, `~`, `^`) and `v` prefix from version requirement strings
+### Fixed
+- Replaced `strings.Replace` with `strings.ReplaceAll` in `ConvertGoPurlStringToGithub` to satisfy linter
 
 ## [0.2.0] - 2023-11-07
 ### Added
@@ -25,3 +29,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.1]: https://github.com/scanoss/go-purl-helper/compare/v0.0.0...v0.0.1
 [0.1.0]: https://github.com/scanoss/go-purl-helper/compare/v0.0.1...v0.1.0
 [0.2.0]: https://github.com/scanoss/go-purl-helper/compare/v0.1.0...v0.2.0
+[0.3.0]: https://github.com/scanoss/go-purl-helper/compare/v0.2.0...v0.3.0

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+## Constants
+# Linter version
+LINT_VERSION := v2.10.1
 
 # HELP
 # This will output the help for each task
@@ -19,8 +22,18 @@ unit_test:  ## Run all unit tests in the pkg folder
 
 test:  unit_test ## Run package tests
 
+unit_test_coverage:  ## Run all unit tests in the pkg folder and get test coverage
+	@echo "Running unit test with coverage..."
+	go test -coverprofile=coverage.txt ./... && go tool cover -func=coverage.txt
+
 lint_local: ## Run local instance of linting across the code base
 	golangci-lint run ./...
 
+lint_local_fix: ## Run local instance of linting across the code base including auto-fixing
+	golangci-lint run --fix ./...
+
 lint_docker: ## Run docker instance of linting across the code base
-	docker run --rm -v $(PWD):/app -v ~/.cache/golangci-lint/v1.50.1:/root/.cache -w /app golangci/golangci-lint:v1.50.1 golangci-lint run ./...
+	docker run --rm -v $(PWD):/app -v ~/.cache/golangci-lint/$(LINT_VERSION):/root/.cache -w /app golangci/golangci-lint:$(LINT_VERSION) golangci-lint run ./...
+
+lint_docker_fix: ## Run docker instance of linting across the code base including auto-fixing
+	docker run --rm -v $(PWD):/app -v ~/.cache/golangci-lint/$(LINT_VERSION):/root/.cache -w /app golangci/golangci-lint:$(LINT_VERSION) golangci-lint run --fix ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/scanoss/go-purl-helper
 
-go 1.17
+go 1.24
 
-require github.com/package-url/packageurl-go v0.1.3
+require github.com/package-url/packageurl-go v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=

--- a/pkg/purl.go
+++ b/pkg/purl.go
@@ -21,17 +21,16 @@
  * THE SOFTWARE.
  */
 
+// Package purlutils provides utilities for working with Package URL (PURL) strings.
 package purlutils
 
 import (
 	"errors"
-	"github.com/package-url/packageurl-go"
-	"regexp"
-)
-
-import (
 	"fmt"
+	"regexp"
 	"strings"
+
+	"github.com/package-url/packageurl-go"
 )
 
 var pkgRegex = regexp.MustCompile(`^pkg:(?P<type>\w+)/(?P<name>.+)$`) // regex to parse purl name from purl string
@@ -40,7 +39,7 @@ var vRegex = regexp.MustCompile(`^(=|==|)(?P<name>\w+\S+)$`)          // regex t
 // vReqRegex strips all common semver operators (>=, <=, !=, ~=, ==, >, <, =, ~, ^) from a version requirement string.
 var vReqRegex = regexp.MustCompile(`^(?:>=|<=|!=|~=|==|[><=~^])?v?(?P<version>\d\S+)$`)
 
-// PurlFromString takes an input Purl string and returns a decomposed structure of all the elements
+// PurlFromString takes an input Purl string and returns a decomposed structure of all the elements.
 func PurlFromString(purlString string) (packageurl.PackageURL, error) {
 	if len(purlString) == 0 {
 		return packageurl.PackageURL{}, errors.New("no Purl string specified to parse")
@@ -52,7 +51,7 @@ func PurlFromString(purlString string) (packageurl.PackageURL, error) {
 	return purl, nil
 }
 
-// PurlNameFromString take an input Purl string and returns the Purl Name only
+// PurlNameFromString take an input Purl string and returns the Purl Name only.
 func PurlNameFromString(purlString string) (string, error) {
 	if len(purlString) == 0 {
 		return "", fmt.Errorf("no purl string supplied to parse")
@@ -74,7 +73,7 @@ func PurlNameFromString(purlString string) (string, error) {
 	return "", fmt.Errorf("no purl name found in '%v'", purlString)
 }
 
-// ConvertGoPurlStringToGithub takes an input PURL string and converts it to its GitHub equivalent if possible
+// ConvertGoPurlStringToGithub takes an input PURL string and converts it to its GitHub equivalent if possible.
 func ConvertGoPurlStringToGithub(purlString string) string {
 	// Replace Golang GitHub package reference with just GitHub
 	if len(purlString) > 0 && strings.HasPrefix(purlString, "pkg:golang/github.com/") {
@@ -88,7 +87,7 @@ func ConvertGoPurlStringToGithub(purlString string) string {
 	return purlString
 }
 
-// GetVersionFromReq parses a requirement string looking for an exact version specifier
+// GetVersionFromReq parses a requirement string looking for an exact version specifier.
 func GetVersionFromReq(purlReq string) string {
 	matches := vRegex.FindStringSubmatch(purlReq)
 	if len(matches) > 0 {
@@ -113,8 +112,8 @@ func GetVersionFromReqOperator(purlReq string) string {
 	return ""
 }
 
-// ProjectUrl returns a browsable URL for the given purl type and name
-func ProjectUrl(purlName, purlType string) (string, error) {
+// ProjectUrl returns a browsable URL for the given purl type and name.
+func ProjectUrl(purlName, purlType string) (string, error) { //nolint:staticcheck
 	if len(purlName) == 0 {
 		return "", fmt.Errorf("no purl name supplied")
 	}
@@ -136,6 +135,8 @@ func ProjectUrl(purlName, purlType string) (string, error) {
 		return fmt.Sprintf("https://pkg.go.dev/%v", purlName), nil
 	case "nuget":
 		return fmt.Sprintf("https://www.nuget.org/packages/%v", purlName), nil
+	case "conan":
+		return fmt.Sprintf("https://conan.io/center/recipes/%v", purlName), nil
 	}
 	return "", fmt.Errorf("no url prefix found for '%v': %v", purlType, purlName)
 }

--- a/pkg/purl.go
+++ b/pkg/purl.go
@@ -36,7 +36,9 @@ import (
 
 var pkgRegex = regexp.MustCompile(`^pkg:(?P<type>\w+)/(?P<name>.+)$`) // regex to parse purl name from purl string
 var typeRegex = regexp.MustCompile(`^(npm|nuget)$`)                   // regex to parse purl types that should not be lower cased
-var vRegex = regexp.MustCompile(`^(=|==|)(?P<name>\w+\S+)$`)          // regex to parse purl name from purl string
+var vRegex = regexp.MustCompile(`^(=|==|)(?P<name>\w+\S+)$`)          // regex to strip version operators and parse version string
+// vReqRegex strips all common semver operators (>=, <=, !=, ~=, ==, >, <, =, ~, ^) from a version requirement string.
+var vReqRegex = regexp.MustCompile(`^(?:>=|<=|!=|~=|==|[><=~^])?v?(?P<version>\d\S+)$`)
 
 // PurlFromString takes an input Purl string and returns a decomposed structure of all the elements
 func PurlFromString(purlString string) (packageurl.PackageURL, error) {
@@ -76,7 +78,7 @@ func PurlNameFromString(purlString string) (string, error) {
 func ConvertGoPurlStringToGithub(purlString string) string {
 	// Replace Golang GitHub package reference with just GitHub
 	if len(purlString) > 0 && strings.HasPrefix(purlString, "pkg:golang/github.com/") {
-		s := strings.Replace(purlString, "pkg:golang/github.com/", "pkg:github/", -1)
+		s := strings.ReplaceAll(purlString, "pkg:golang/github.com/", "pkg:github/")
 		p := strings.Split(s, "/")
 		if len(p) >= 3 {
 			return fmt.Sprintf("%s/%s/%s", p[0], p[1], p[2]) // Only return the GitHub part of the url
@@ -93,6 +95,19 @@ func GetVersionFromReq(purlReq string) string {
 		ni := vRegex.SubexpIndex("name")
 		if ni >= 0 {
 			return matches[ni]
+		}
+	}
+	return ""
+}
+
+// GetVersionFromReqOperator parses a requirement string stripping any semver operator prefix
+// and returns the version portion. Supports: >=, <=, !=, ~=, ==, >, <, =, ~, ^, or no operator.
+func GetVersionFromReqOperator(purlReq string) string {
+	matches := vReqRegex.FindStringSubmatch(purlReq)
+	if len(matches) > 0 {
+		vi := vReqRegex.SubexpIndex("version")
+		if vi >= 0 {
+			return matches[vi]
 		}
 	}
 	return ""

--- a/pkg/purl_test.go
+++ b/pkg/purl_test.go
@@ -24,15 +24,15 @@
 package purlutils
 
 import (
-	"github.com/package-url/packageurl-go"
 	"reflect"
 	"testing"
+
+	"github.com/package-url/packageurl-go"
 )
 
 // Help with test details can be found here: https://go.dev/doc/code
 
 func TestPurlFromString(t *testing.T) {
-
 	w, _ := packageurl.FromString("pkg:maven/io.prestosql/presto-main@v1.0")
 	w2, _ := packageurl.FromString("pkg:npm/%40babel/core")
 	tests := []struct {
@@ -230,6 +230,12 @@ func TestPurlUrl(t *testing.T) {
 			pname: "System.Buffers",
 			ptype: "nuget",
 			want:  "https://www.nuget.org/packages/System.Buffers",
+		},
+		{
+			name:  "Conan",
+			pname: "boost",
+			ptype: "conan",
+			want:  "https://conan.io/center/recipes/boost",
 		},
 		{
 			name:    "Empty String1",

--- a/pkg/purl_test.go
+++ b/pkg/purl_test.go
@@ -298,3 +298,95 @@ func TestGetVersionFromReq(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVersionFromReqOperator(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "No operator",
+			input: "1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "Version with v prefix",
+			input: "v1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "Greater than",
+			input: ">1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "Greater or equal",
+			input: ">=1.2.3",
+			want:  "1.2.3",
+		},
+		{
+			name:  "Less than",
+			input: "<2.0.0",
+			want:  "2.0.0",
+		},
+		{
+			name:  "Less or equal",
+			input: "<=2.0.0",
+			want:  "2.0.0",
+		},
+		{
+			name:  "Not equal",
+			input: "!=1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "Tilde equal",
+			input: "~=1.4.2",
+			want:  "1.4.2",
+		},
+		{
+			name:  "Tilde",
+			input: "~1.4.2",
+			want:  "1.4.2",
+		},
+		{
+			name:  "Caret",
+			input: "^1.4.2",
+			want:  "1.4.2",
+		},
+		{
+			name:  "Double equal",
+			input: "==1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "Single equal",
+			input: "=1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "Operator with v prefix",
+			input: ">=v1.2.3",
+			want:  "1.2.3",
+		},
+		{
+			name:  "Double equal with v prefix",
+			input: "==v1.0.0",
+			want:  "1.0.0",
+		},
+		{
+			name:  "Empty string",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetVersionFromReqOperator(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetVersionFromReqOperator(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…erators from version requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version extraction now strips common semver operators and leading "v".
  * Added support for converting Conan package identifiers to project URLs.

* **Bug Fixes**
  * Improved GitHub URL rewrite to use a safer string-replace approach.

* **Tests**
  * Added comprehensive tests for version-operator extraction and related cases.

* **Chores**
  * Updated changelog, CI/toolchain and lint configurations, Makefile targets, ignore patterns, and Go toolchain/dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->